### PR TITLE
Apps/handle reuse of logtags

### DIFF
--- a/app/src/main/java/com/telefonica/androidlogger/app/LoggerConfig.kt
+++ b/app/src/main/java/com/telefonica/androidlogger/app/LoggerConfig.kt
@@ -14,22 +14,31 @@ object LoggerConfig {
     const val LOGTAG_THEIR_VIEW_MODEL = "TheirViewModel"
 
     val categories: List<LogCategory> = listOf(
-        LogCategory(
-            name = "My Category",
-            color = Color.parseColor("#28A745"),
-            logTags = listOf(
-                LOGTAG_MY_ACTIVITY,
-                LOGTAG_MY_FRAGMENT,
-                LOGTAG_MY_SERVICE
-            )
-        ),
-        LogCategory(
-            name = "Your Category",
-            color = Color.parseColor("#17A2B8"),
-            logTags = listOf(
-                LOGTAG_YOUR_STORAGE,
-                LOGTAG_YOUR_API_CLIENT
-            )
-        ),
+            LogCategory(
+                    name = "My Category",
+                    color = Color.parseColor("#28A745"),
+                    logTags = listOf(
+                            LOGTAG_MY_ACTIVITY,
+                            LOGTAG_MY_FRAGMENT,
+                            LOGTAG_MY_SERVICE
+                    )
+            ),
+            LogCategory(
+                    name = "Your Category",
+                    color = Color.parseColor("#17A2B8"),
+                    logTags = listOf(
+                            LOGTAG_YOUR_STORAGE,
+                            LOGTAG_YOUR_API_CLIENT
+                    )
+            ),
+            LogCategory(
+                    name = "Category reusing logtags",
+                    color = Color.parseColor("#46598C"),
+                    logTags = listOf(
+                            LOGTAG_YOUR_STORAGE,
+                            LOGTAG_YOUR_API_CLIENT,
+                            LOGTAG_MY_SERVICE
+                    )
+            ),
     )
 }

--- a/app/src/main/java/com/telefonica/androidlogger/app/MainActivity.kt
+++ b/app/src/main/java/com/telefonica/androidlogger/app/MainActivity.kt
@@ -30,7 +30,14 @@ class MainActivity : AppCompatActivity() {
             }
         }
         findViewById<Button>(R.id.button_show_logger).setOnClickListener {
-            startActivity(getLaunchIntent(this, emptyList()))
+            startActivity(
+                    getLaunchIntent(this,
+                    listOf(
+                            LoggerConfig.categories[1],
+                            LoggerConfig.categories[0],
+                            LoggerConfig.categories[2])
+                    )
+            )
         }
     }
 

--- a/library/src/enabled/java/com/telefonica/androidlogger/ui/adapter/LogListAdapter.kt
+++ b/library/src/enabled/java/com/telefonica/androidlogger/ui/adapter/LogListAdapter.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.telefonica.androidlogger.R
 import com.telefonica.androidlogger.ui.holder.LogListItemHolder
 import com.telefonica.androidlogger.ui.viewmodel.AppLoggerViewModel
+import com.telefonica.androidlogger.ui.viewmodel.LogCategoryViewModel
 import com.telefonica.androidlogger.ui.viewmodel.LogEntryViewModel
 import kotlin.math.min
 
@@ -37,19 +38,24 @@ internal class LogListAdapter(
             )
             holder.message.maxLines = if (expanded) Int.MAX_VALUE else DEFAULT_MESSAGE_LINES
             holder.message.setTextColor(priority.color)
-
-            if (categories.isNullOrEmpty()) {
-                holder.indicator.setBackgroundColor(Color.TRANSPARENT)
-            } else {
-                val gradientDrawable = GradientDrawable(GradientDrawable.Orientation.TOP_BOTTOM, categories.map { it.color }.toIntArray())
-                holder.indicator.background = gradientDrawable
-            }
+            setIndicatorBackground(holder, categories)
             holder.container.setOnClickListener {
                 viewModel.onLogClicked(this)
             }
             holder.container.setOnLongClickListener {
                 copyMessageToClipboard(it.context, message)
                 true
+            }
+        }
+    }
+
+    private fun setIndicatorBackground(holder: LogListItemHolder, categories: List<LogCategoryViewModel>?) {
+        when {
+            categories.isNullOrEmpty() -> holder.indicator.setBackgroundColor(Color.TRANSPARENT)
+            categories.size == 1 -> holder.indicator.setBackgroundColor(categories[0].color)
+            else -> {
+                val gradientDrawable = GradientDrawable(GradientDrawable.Orientation.TOP_BOTTOM, categories.map { it.color }.toIntArray())
+                holder.indicator.background = gradientDrawable
             }
         }
     }

--- a/library/src/enabled/java/com/telefonica/androidlogger/ui/adapter/LogListAdapter.kt
+++ b/library/src/enabled/java/com/telefonica/androidlogger/ui/adapter/LogListAdapter.kt
@@ -4,41 +4,46 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.Toast
-
-import com.telefonica.androidlogger.R
-
-import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.telefonica.androidlogger.R
 import com.telefonica.androidlogger.ui.holder.LogListItemHolder
 import com.telefonica.androidlogger.ui.viewmodel.AppLoggerViewModel
 import com.telefonica.androidlogger.ui.viewmodel.LogEntryViewModel
 import kotlin.math.min
 
 internal class LogListAdapter(
-    private val viewModel: AppLoggerViewModel
+        private val viewModel: AppLoggerViewModel
 ) : RecyclerView.Adapter<LogListItemHolder>() {
 
     private var logEntryList: List<LogEntryViewModel> = emptyList()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): LogListItemHolder =
-        LogListItemHolder(
-            LayoutInflater.from(parent.context).inflate(R.layout.log_row_item, parent, false)
-        )
+            LogListItemHolder(
+                    LayoutInflater.from(parent.context).inflate(R.layout.log_row_item, parent, false)
+            )
 
     override fun onBindViewHolder(holder: LogListItemHolder, position: Int) {
         with(logEntryList[position]) {
             holder.header.text = header
             holder.header.setTextColor(priority.color)
             holder.message.text = if (expanded) message else message.substring(
-                0,
-                min(message.length, MAX_TEXT_LENGTH_NOT_EXPANDED)
+                    0,
+                    min(message.length, MAX_TEXT_LENGTH_NOT_EXPANDED)
             )
             holder.message.maxLines = if (expanded) Int.MAX_VALUE else DEFAULT_MESSAGE_LINES
             holder.message.setTextColor(priority.color)
-            holder.indicator.setBackgroundColor(category?.color ?: Color.TRANSPARENT)
+
+            if (categories.isNullOrEmpty()) {
+                holder.indicator.setBackgroundColor(Color.TRANSPARENT)
+            } else {
+                val gradientDrawable = GradientDrawable(GradientDrawable.Orientation.TOP_BOTTOM, categories.map { it.color }.toIntArray())
+                holder.indicator.background = gradientDrawable
+            }
             holder.container.setOnClickListener {
                 viewModel.onLogClicked(this)
             }
@@ -75,19 +80,19 @@ internal class LogListAdapter(
     }
 
     fun getVisibleInfoAsString(): String =
-        logEntryList.joinToString("\n") { "${it.header}: ${it.message}" }
+            logEntryList.joinToString("\n") { "${it.header}: ${it.message}" }
 
     private fun copyMessageToClipboard(context: Context, message: String) {
         val clipboard: ClipboardManager =
-            context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         val clip = ClipData.newPlainText(context.getString(R.string.copy_clipboard_label), message)
         clipboard.setPrimaryClip(clip)
         Toast.makeText(
-            context,
-            context.getString(R.string.copy_clipboard_success),
-            Toast.LENGTH_SHORT
+                context,
+                context.getString(R.string.copy_clipboard_success),
+                Toast.LENGTH_SHORT
         )
-            .show()
+                .show()
     }
 
     private companion object {

--- a/library/src/enabled/java/com/telefonica/androidlogger/ui/adapter/LogListAdapter.kt
+++ b/library/src/enabled/java/com/telefonica/androidlogger/ui/adapter/LogListAdapter.kt
@@ -54,7 +54,10 @@ internal class LogListAdapter(
             categories.isNullOrEmpty() -> holder.indicator.setBackgroundColor(Color.TRANSPARENT)
             categories.size == 1 -> holder.indicator.setBackgroundColor(categories[0].color)
             else -> {
-                val gradientDrawable = GradientDrawable(GradientDrawable.Orientation.TOP_BOTTOM, categories.map { it.color }.toIntArray())
+                val gradientDrawable = GradientDrawable(
+                        GradientDrawable.Orientation.TOP_BOTTOM,
+                        categories.map { it.color }.toIntArray()
+                )
                 holder.indicator.background = gradientDrawable
             }
         }

--- a/library/src/enabled/java/com/telefonica/androidlogger/ui/viewmodel/AppLoggerViewMappers.kt
+++ b/library/src/enabled/java/com/telefonica/androidlogger/ui/viewmodel/AppLoggerViewMappers.kt
@@ -6,29 +6,31 @@ import com.telefonica.androidlogger.domain.LogEntry
 import java.text.SimpleDateFormat
 
 internal fun LogEntry.toViewModel(
-    dateFormat: SimpleDateFormat,
-    expanded: Boolean
+        dateFormat: SimpleDateFormat,
+        expanded: Boolean
 ) = LogEntryViewModel(
-    id = id,
-    priority = priority.toLogPriority(),
-    header = "${dateFormat.format(date)} - $tag",
-    category = category?.toViewModel(),
-    message = message,
-    expanded = expanded
+        id = id,
+        priority = priority.toLogPriority(),
+        header = "${dateFormat.format(date)} - $tag",
+        categories = categories?.toViewModel(),
+        message = message,
+        expanded = expanded
 )
 
+internal fun List<LogCategory>.toViewModel() = map { it.toViewModel() }
+
 internal fun LogCategory.toViewModel() = LogCategoryViewModel(
-    name = name,
-    color = color
+        name = name,
+        color = color
 )
 
 internal fun Int.toLogPriority() =
-    when {
-        this < Log.VERBOSE -> LogPriorityViewModel.VERBOSE
-        this == Log.VERBOSE -> LogPriorityViewModel.VERBOSE
-        this == Log.DEBUG -> LogPriorityViewModel.DEBUG
-        this == Log.INFO -> LogPriorityViewModel.INFO
-        this == Log.WARN -> LogPriorityViewModel.WARN
-        this == Log.ERROR -> LogPriorityViewModel.ERROR
-        else -> LogPriorityViewModel.ASSERT
-    }
+        when {
+            this < Log.VERBOSE -> LogPriorityViewModel.VERBOSE
+            this == Log.VERBOSE -> LogPriorityViewModel.VERBOSE
+            this == Log.DEBUG -> LogPriorityViewModel.DEBUG
+            this == Log.INFO -> LogPriorityViewModel.INFO
+            this == Log.WARN -> LogPriorityViewModel.WARN
+            this == Log.ERROR -> LogPriorityViewModel.ERROR
+            else -> LogPriorityViewModel.ASSERT
+        }

--- a/library/src/enabled/java/com/telefonica/androidlogger/ui/viewmodel/AppLoggerViewModels.kt
+++ b/library/src/enabled/java/com/telefonica/androidlogger/ui/viewmodel/AppLoggerViewModels.kt
@@ -118,8 +118,10 @@ internal class AppLoggerViewModel : ViewModel() {
                 isEmptyCategoriesSelection && !showCategoriesLogsOnly
         return filter { logEntry ->
             logEntry.categories?.let { logEntryCategories ->
-                val availableCategoriesMatching = logEntryCategories.filter { availableCategories.contains(it.toViewModel()) }
-                val selectedCategoriesMatching = logEntryCategories.filter { selectedCategories.contains(it.toViewModel()) }
+                val availableCategoriesMatching = logEntryCategories
+                        .filter { availableCategories.contains(it.toViewModel()) }
+                val selectedCategoriesMatching = logEntryCategories
+                        .filter { selectedCategories.contains(it.toViewModel()) }
                 (isEmptyCategoriesSelection && availableCategoriesMatching.isNotEmpty())
                         || selectedCategoriesMatching.isNotEmpty()
             } ?: isEmptyFiltersSelectionWithAllCategories

--- a/library/src/enabled/java/com/telefonica/androidlogger/ui/viewmodel/AppLoggerViewModels.kt
+++ b/library/src/enabled/java/com/telefonica/androidlogger/ui/viewmodel/AppLoggerViewModels.kt
@@ -117,7 +117,7 @@ internal class AppLoggerViewModel : ViewModel() {
         val isEmptyFiltersSelectionWithAllCategories =
             isEmptyCategoriesSelection && !showCategoriesLogsOnly
         return filter { entry ->
-            entry.category?.let {
+            entry.categories?.let {
                 (isEmptyCategoriesSelection && availableCategories.contains(it.toViewModel()))
                         || selectedCategories.contains(it.toViewModel())
             } ?: isEmptyFiltersSelectionWithAllCategories
@@ -131,12 +131,12 @@ internal class AppLoggerViewModel : ViewModel() {
 }
 
 internal data class LogEntryViewModel(
-    val id: Int,
-    val priority: LogPriorityViewModel,
-    val header: String,
-    val category: LogCategoryViewModel?,
-    val message: String,
-    val expanded: Boolean
+        val id: Int,
+        val priority: LogPriorityViewModel,
+        val header: String,
+        val categories: List<LogCategoryViewModel>?,
+        val message: String,
+        val expanded: Boolean
 )
 
 internal data class LogCategoryViewModel(

--- a/library/src/enabled/java/com/telefonica/androidlogger/ui/viewmodel/AppLoggerViewModels.kt
+++ b/library/src/enabled/java/com/telefonica/androidlogger/ui/viewmodel/AppLoggerViewModels.kt
@@ -115,13 +115,26 @@ internal class AppLoggerViewModel : ViewModel() {
     private fun List<LogEntry>.filterBySelectedCategories(): List<LogEntry> {
         val isEmptyCategoriesSelection = selectedCategories.isEmpty()
         val isEmptyFiltersSelectionWithAllCategories =
-            isEmptyCategoriesSelection && !showCategoriesLogsOnly
-        return filter { entry ->
-            entry.categories?.let {
-                (isEmptyCategoriesSelection && availableCategories.contains(it.toViewModel()))
-                        || selectedCategories.contains(it.toViewModel())
+                isEmptyCategoriesSelection && !showCategoriesLogsOnly
+        return filter { logEntry ->
+            logEntry.categories?.let { logEntryCategories ->
+                val availableCategoriesMatching = logEntryCategories.filter { availableCategories.contains(it.toViewModel()) }
+                val selectedCategoriesMatching = logEntryCategories.filter { selectedCategories.contains(it.toViewModel()) }
+                (isEmptyCategoriesSelection && availableCategoriesMatching.isNotEmpty())
+                        || selectedCategoriesMatching.isNotEmpty()
             } ?: isEmptyFiltersSelectionWithAllCategories
+        }.map { getLogEntryWithFilteredCategories(it) }
+    }
+
+    private fun getLogEntryWithFilteredCategories(logEntry: LogEntry): LogEntry {
+        logEntry.categories?.let { logEntryCategories ->
+            val filteredCategories = logEntryCategories.filter {
+                availableCategories.contains(it.toViewModel())
+                        || selectedCategories.contains(it.toViewModel())
+            }
+            return logEntry.copy(categories = filteredCategories)
         }
+        return logEntry
     }
 
     private fun filter() {

--- a/library/src/main/java/com/telefonica/androidlogger/domain/AppLoggerModels.kt
+++ b/library/src/main/java/com/telefonica/androidlogger/domain/AppLoggerModels.kt
@@ -6,27 +6,27 @@ import androidx.annotation.IntDef
 import java.util.*
 
 data class LogCategory(
-    val name: String,
-    @ColorInt val color: Int,
-    val logTags: List<String>
+        val name: String,
+        @ColorInt val color: Int,
+        val logTags: List<String>
 )
 
 @Retention(AnnotationRetention.SOURCE)
 @IntDef(
-    Log.VERBOSE,
-    Log.DEBUG,
-    Log.INFO,
-    Log.WARN,
-    Log.ERROR,
-    Log.ASSERT
+        Log.VERBOSE,
+        Log.DEBUG,
+        Log.INFO,
+        Log.WARN,
+        Log.ERROR,
+        Log.ASSERT
 )
 annotation class LogPriority
 
 data class LogEntry(
-    val id: Int,
-    @LogPriority val priority: Int,
-    val date: Date,
-    val tag: String,
-    val category: LogCategory?,
-    val message: String
+        val id: Int,
+        @LogPriority val priority: Int,
+        val date: Date,
+        val tag: String,
+        val categories: List<LogCategory>?,
+        val message: String
 )


### PR DESCRIPTION
### :tickets: Jira ticket
[ANDROID-9118](https://jira.tid.es/browse/ANDROID-9118)

### :goal_net: What's the goal?
Currently, logger does not support setting the same LogTag across several LogCategory entities. So if we set a config such as this one where we want to use the same LogTag across multiple categories: 
```kotlin
    val categories: List<LogCategory> = listOf(
            LogCategory(
                    name = "Logs category 1",
                    color = Color.parseColor("#28A745"),
                    logTags = listOf(
                            LOGTAG_MY_ACTIVITY,
                            LOGTAG_MY_FRAGMENT,
                            LOGTAG_MY_SERVICE
                    )
            ),
            LogCategory(
                    name = "Logs category 1",
                    color = Color.parseColor("#17A2B8"),
                    logTags = listOf(
                            LOGTAG_YOUR_STORAGE,
                            LOGTAG_YOUR_API_CLIENT
                    )
            ),
            LogCategory(
                    name = "Category reusing logtags from 1 and 2",
                    color = Color.parseColor("#46598C"),
                    logTags = listOf(
                            LOGTAG_YOUR_STORAGE,
                            LOGTAG_YOUR_API_CLIENT,
                            LOGTAG_MY_SERVICE
                    )
            ),
    )

``` 
What will happen for logtags reused multiple times is that the Logger will only keep the last ones. Why? Because at `AppLoggerBL` we map LogTags to LogCategories in a 1:1 relationship: 
```kotlin
    open fun init(appContext: Context, logCategories: List<LogCategory>) {
        categories = logCategories
        tagsMap = categories
            .flatMap { category ->
                category.logTags.map { tag ->
                    tag to category
                }
            }.toMap()
        logsData.value = emptyList()
        fileLogger.init()
    }
```
Using the function `toMap` will behave like this "If any of two pairs would have the same key the last one gets added to the map." So we will lose information and won't properly filter the Logs and won't be able to display the color indicator properly. 

### :construction: How do we do it?
To fix this what we will do is: 
* Change the relation LogTag -> LogCategory from 1:1 to 1:n
* Update the filtering logic at viewmodel level to handle this 1:n relation and ensure we display all the logtags that belong in the Category been applied. 
* When painting the color indicator for LogEntry in `LogListAdapter`  we will use a color gradient using the colors of the LogCategories that the Logtag belongs to. 

### :test_tube: How can I test this?
Run the app using some test input categories and test that everything works as expected. Using the sample categories displayed at the top of this description and configuring the AppLoggerScreen to be opened with this values: 
```kotlin 
            startActivity(
                    getLaunchIntent(this,
                    listOf(
                            LoggerConfig.categories[1],
                            LoggerConfig.categories[0],
                            LoggerConfig.categories[2])
                    )
            )
```
This is the resulting UI


https://user-images.githubusercontent.com/2663464/112300653-60fcd780-8c99-11eb-92ca-7842fca50b1b.mp4

