### PR TITLE
ANDROID-11132 Change development branch to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: "Run tests"
 on:
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/mavencentral.gradle
+++ b/mavencentral.gradle
@@ -63,7 +63,7 @@ publishing {
                 scm {
                     connection = 'scm:git:github.com/Telefonica/android-logger.git'
                     developerConnection = 'scm:git:ssh://github.com/Telefonica/android-logger.git'
-                    url = 'https://github.com/Telefonica/android-logger/tree/master'
+                    url = 'https://github.com/Telefonica/android-logger/tree/main'
                 }
                 withXml {
                     def dependenciesNode = asNode().appendNode('dependencies')
@@ -105,7 +105,7 @@ publishing {
                 scm {
                     connection = 'scm:git:github.com/Telefonica/android-logger.git'
                     developerConnection = 'scm:git:ssh://github.com/Telefonica/android-logger.git'
-                    url = 'https://github.com/Telefonica/android-logger/tree/master'
+                    url = 'https://github.com/Telefonica/android-logger/tree/main'
                 }
                 withXml {
                     def dependenciesNode = asNode().appendNode('dependencies')


### PR DESCRIPTION
In order to align all our repositories, we are going to change the development branch from `master` to `main`.