### PR TITLE
Manual trigger of action Generate release for testing purposes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: "Create release"
 on:
   release:
       types: [published]
+  workflow_dispatch:
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Enable manual trigger of action Generate release for testing purposes (equivalent of this PR https://github.com/Telefonica/tweaks/pull/26).
This change will be undo in the next PR