### PR TITLE
Upgrade elvishew to last version

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation "androidx.annotation:annotation:1.1.0"
     enabledImplementation "com.google.android.material:material:$support_version"
     enabledImplementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
-    enabledImplementation "com.elvishew:xlog:1.3.0"
+    enabledImplementation "com.elvishew:xlog:1.11.0"
     enabledImplementation "com.squareup.okio:okio:2.7.0"
 
     testImplementation 'junit:junit:4.13'


### PR DESCRIPTION
The purpose of the upgrade is to tackle the SW crash related to [this jira ticket](https://jira.tid.es/browse/SMARTWIFI-8078).

I found out we were using this library to log in smart wifi and the usage of elvishew so I searched for occurrences of the stack trace we had on the dependency's official repository.

There were many reports of this crash taking place in other apps, see:
- https://github.com/elvishew/xLog/issues/70
- https://github.com/elvishew/xLog/issues/93
- https://github.com/elvishew/xLog/issues/76

The given solution by the dependency's developer was to upgrade to at least version 1.8.0 in order to fix this bug which is explained in further detail in the first issue of the list.

The solution was taken in [this other PR](https://github.com/elvishew/xLog/pull/95).