### PR TITLE
Sharing visible logs via file

### DIFF
--- a/library/src/enabled/java/com/telefonica/androidlogger/domain/AppLogger.kt
+++ b/library/src/enabled/java/com/telefonica/androidlogger/domain/AppLogger.kt
@@ -38,3 +38,7 @@ internal fun getCategories(): List<LogCategory> =
 internal fun getPersistedLogs(callback: TaskCallback<Uri>) {
     appLoggerBLInstance?.getPersistedLogs(callback)
 }
+
+internal fun storeVisibleLogs(visibleLogs: String, callback: TaskCallback<Uri>) {
+    appLoggerBLInstance?.storeVisibleLogs(visibleLogs, callback)
+}

--- a/library/src/enabled/java/com/telefonica/androidlogger/domain/AppLoggerBL.kt
+++ b/library/src/enabled/java/com/telefonica/androidlogger/domain/AppLoggerBL.kt
@@ -58,6 +58,10 @@ internal open class AppLoggerBL(
         fileLogger.getReport(callback)
     }
 
+    fun storeVisibleLogs(visibleLogs: String, callback: TaskCallback<Uri>) {
+        fileLogger.storeVisibleLogs(visibleLogs, callback)
+    }
+
     private fun addLog(logEntry: LogEntry) {
         synchronized(logs) {
             logs.addLast(logEntry)

--- a/library/src/enabled/java/com/telefonica/androidlogger/io/AppFileLogger.kt
+++ b/library/src/enabled/java/com/telefonica/androidlogger/io/AppFileLogger.kt
@@ -58,11 +58,23 @@ internal open class AppFileLogger(
             callback = callback
         )
 
-    private fun buildLogReportFile(): File {
-        val outputDir = File(appContext.cacheDir, REPORTS_DIRECTORY).apply { mkdir() }
-        val outputFile =
-            File.createTempFile(TEMPORAL_FILE_PREFIX, TEMPORAL_FILE_EXTENSION, outputDir)
+    fun storeVisibleLogs(visibleLogs: String, callback: TaskCallback<Uri>) {
+        executor.submit(
+            task = {
+                val outputFile = createTempFile()
+                outputFile.writeText(visibleLogs)
+                FileProvider.getUriForFile(
+                    appContext,
+                    appContext.packageName + FILE_PROVIDER_AUTHORITY_SUFFIX,
+                    outputFile
+                )
+            },
+            callback = callback
+        )
+    }
 
+    private fun buildLogReportFile(): File {
+        val outputFile = createTempFile()
         var source: Source? = null
         var sink: BufferedSink? = null
         try {
@@ -75,6 +87,11 @@ internal open class AppFileLogger(
         }
 
         return outputFile
+    }
+
+    private fun createTempFile(): File {
+        val outputDir = File(appContext.cacheDir, REPORTS_DIRECTORY).apply { mkdir() }
+        return File.createTempFile(TEMPORAL_FILE_PREFIX, TEMPORAL_FILE_EXTENSION, outputDir)
     }
 
     private fun buildLogReportStream(): InputStream =

--- a/library/src/enabled/java/com/telefonica/androidlogger/ui/AppLoggerActivity.kt
+++ b/library/src/enabled/java/com/telefonica/androidlogger/ui/AppLoggerActivity.kt
@@ -39,6 +39,7 @@ import com.telefonica.androidlogger.io.executor.TaskCallback
 import com.telefonica.androidlogger.ui.viewmodel.AppLoggerViewModel
 import com.telefonica.androidlogger.ui.viewmodel.LogCategoryViewModel
 import com.telefonica.androidlogger.ui.viewmodel.LogPriorityViewModel
+import java.io.File
 import java.security.InvalidParameterException
 
 class AppLoggerActivity : AppCompatActivity() {
@@ -286,12 +287,19 @@ class AppLoggerActivity : AppCompatActivity() {
     }
 
     private fun shareVisibleLogs() {
-        val shareIntent = Intent.createChooser(Intent().apply {
-            action = Intent.ACTION_SEND
-            type = "text/plain"
-            putExtra(Intent.EXTRA_TEXT, adapter.getVisibleInfoAsString())
-        }, null)
-        startActivity(shareIntent)
+        val visibleInfoAsString: String = adapter.getVisibleInfoAsString()
+        shareAllLogsCallback = TaskCallback<Uri> { uri ->
+            mainThreadHandler.post {
+                if (uri != null) {
+                    launchShareAllLogsIntent(uri)
+                } else {
+                    Toast.makeText(this, R.string.share_visible_logs_failure, Toast.LENGTH_SHORT)
+                        .show()
+                }
+            }
+        }.apply {
+            viewModel.onLogsThatShouldBeStoredIntoAFile(visibleInfoAsString, this)
+        }
     }
 
     private fun shareAllLogs() {

--- a/library/src/enabled/java/com/telefonica/androidlogger/ui/viewmodel/AppLoggerViewModels.kt
+++ b/library/src/enabled/java/com/telefonica/androidlogger/ui/viewmodel/AppLoggerViewModels.kt
@@ -11,6 +11,7 @@ import com.telefonica.androidlogger.domain.LogEntry
 import com.telefonica.androidlogger.domain.getCategories
 import com.telefonica.androidlogger.domain.getLogs
 import com.telefonica.androidlogger.domain.getPersistedLogs
+import com.telefonica.androidlogger.domain.storeVisibleLogs
 import com.telefonica.androidlogger.io.executor.TaskCallback
 import com.telefonica.androidlogger.ui.livedata.filter
 import com.telefonica.androidlogger.ui.livedata.map
@@ -95,6 +96,10 @@ internal class AppLoggerViewModel : ViewModel() {
 
     fun getAllLogs(callback: TaskCallback<Uri>) {
         getPersistedLogs(callback)
+    }
+
+    fun onLogsThatShouldBeStoredIntoAFile(visibleLogs: String, callback: TaskCallback<Uri>) {
+        storeVisibleLogs(visibleLogs, callback)
     }
 
     private fun List<LogEntry>.filterByLogLevel() =

--- a/library/src/enabled/res/values/strings.xml
+++ b/library/src/enabled/res/values/strings.xml
@@ -14,6 +14,7 @@
 	<string name="copy_clipboard_success">Log copied to clipboard!</string>
 
 	<string name="share_all_logs_failure">Something went wrong retrieving persisted logs</string>
+	<string name="share_visible_logs_failure">Something went wrong while sharing visible logs</string>
 
 	<string name="log_level_filter_message">Minimum Log Level</string>
 	<string name="categories_filter_message">Categories</string>


### PR DESCRIPTION
Hello strangers,

We're using your amazing library into our app and it is working great.

Unfortunately, we have an issue in low-quality devices with the share visible logs. That is caused because the logs string may be so big for the bundle and we end up in a transactionTooLarge exception (you can reproduce this spamming a lot of logs (A LOT) and then send them).

With this approach we save the logs to a file and then we share the file