### PR TITLE
ANDROID-16026 Downgrade kotlin version down to 2.0.X

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 activity = "1.10.1"
 android-gradle-plugin = "8.7.3"
 junit = "4.13.2"
-kotlin = "2.1.10"
+kotlin = "2.0.21"
 androidx-lifecycle = "2.2.0"
 material = "1.12.0"
 elviswhew-xlog = "1.11.1"


### PR DESCRIPTION
### What's the goal
We still have 1.9.X as Kotlin version in some of our apps so we shouldn't be using a Kotlin version greater than 2.0.X in our libs until every app updates to Kotlin 2.

### How do we do it?
Downgrade Kotlin version from 2.1.10 down to 2.0.21 (latest 2.0.X version) which is still compatible with 1.9.X.

More info [here](https://kotlinlang.org/docs/kotlin-evolution-principles.html#evolving-the-binary-format):
> Preferably (but we can't guarantee it), the binary format is mostly forwards compatible with the next language release, but not later ones (in the cases when new features are not used, for example, 1.9 can understand most binaries from 2.0, but not 2.1). 