### PR TITLE
ANDROID-16205 Migrate sonatype publishing to Central Portal

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,29 @@
+name: "Snapshot"
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin' # This is the Ubuntu Default
+          java-version: '17'
+          
+      - name: Build library
+        run: 'bash ./gradlew clean :library:assembleRelease'
+          
+      - name: Release library
+        env:
+          MOBILE_MAVENCENTRAL_USER: ${{ secrets.MOBILE_MAVENCENTRAL_USER }}
+          MOBILE_MAVENCENTRAL_PASSWORD: ${{ secrets.MOBILE_MAVENCENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
+        run: "bash ./gradlew publishReleasePublicationToSonatypeRepository -DSNAPSHOT_VERSION=1.0.0 publishNoopPublicationToSonatypeRepository -DSNAPSHOT_VERSION=1.0.0
+        --max-workers 1 closeAndReleaseStagingRepositories"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,7 +1,10 @@
 name: "Snapshot"
 on:
-  push:
   workflow_dispatch:
+    inputs:
+      snapshotVersion:
+        description: "Snapshot version"
+        required: true
 
 jobs:
   release:
@@ -25,5 +28,5 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
-        run: "bash ./gradlew publishReleasePublicationToSonatypeRepository -DSNAPSHOT_VERSION=1.0.0 publishNoopPublicationToSonatypeRepository -DSNAPSHOT_VERSION=1.0.0
+        run: "bash ./gradlew publishReleasePublicationToSonatypeRepository -DSNAPSHOT_VERSION=${{ github.event.inputs.snapshotVersion }} publishNoopPublicationToSonatypeRepository -DSNAPSHOT_VERSION=${{ github.event.inputs.snapshotVersion }}
         --max-workers 1 closeAndReleaseStagingRepositories"

--- a/publish_maven_central.gradle
+++ b/publish_maven_central.gradle
@@ -6,6 +6,8 @@ nexusPublishing {
             stagingProfileId = "f7fe7699e57a"
             username = System.getenv("MOBILE_MAVENCENTRAL_USER")
             password = System.getenv("MOBILE_MAVENCENTRAL_PASSWORD")
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }


### PR DESCRIPTION
- Update publishing urls to point to new namespace in Cental Portal.
- Create missing workflow to publish Snapshots

Evidences:
  - [androidlogger:1.0.0-SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/telefonica/androidlogger/1.0.0-SNAPSHOT/)
  - [androidlogger-noop:1.0.0-SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/telefonica/androidlogger-no-op/1.0.0-SNAPSHOT/)

Once merged I'll test a non-snapshot version release